### PR TITLE
Add LANGUAGES NONE to project()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14) # b/c of FetchContent_MakeAvailable
-project(CMakePPCore VERSION 1.0.0)
+project(CMakePPCore VERSION 1.0.0 LANGUAGES NONE)
 
 option(BUILD_TESTING "Should we build and run the unit tests?" OFF)
 


### PR DESCRIPTION
This addition disables unnecessary C and C++ compiler checking.