### PR TITLE
Migrate documentation to GitHub Pages

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,0 +1,46 @@
+# Copyright 2021 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Build and Deploy Documentation
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  Build-Documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Get Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.10'
+
+      - name: Build Documentation
+        run: |
+          python3 -m venv virt_env
+          source virt_env/bin/activate
+          cd docs
+          pip3 install -r requirements.txt
+          make html
+          deactivate
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/build/html


### PR DESCRIPTION
Closes #27. Migrates documentation from Read the Docs to GitHub Pages to be consistent with the rest of CPP.

This PR will:

- [x] Create a workflow to automatically generate and deploy documentation to GitHub Pages in the `gh-pages` branch.
- [ ] Stop hosting the documentation on Read the Docs.

Questions:

- [x] How is the documentation being uploaded/hosted on Read the Docs? I am not familiar with that workflow, but I do not see a GitHub workflow automatically uploading it.