### PR TITLE
Update .gitignore to ignore all build directories and VSCode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
-#Build directories
-docs/build
+# Build directories
+**/build
 cmake-build-debug
 
 # CLion settings
 .idea
+
+# VSCode settings
+.vscode


### PR DESCRIPTION
This is an update to the `.gitignore` file to ignore:
- all build directories in the project, instead of just `docs/build/`, since `build/` is created during testing
- the VSCode settings directory, `.vscode`